### PR TITLE
Add RHEL support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,42 +13,7 @@
 #
 fusioninventory__agent_version: '2.4-2'
                                                                    # ]]]
-# .. envvar:: fusioninventory__agent_depend_packages [[[
-#
-# List of dependent packages to install.
-fusioninventory__agent_depend_packages:
-  - 'dmidecode'
-  - 'hwdata'
-  - 'hdparm'
-  - 'libuniversal-require-perl'
-  - 'libwww-perl'
-  - 'libparse-edid-perl'
-  - 'libproc-daemon-perl'
-  - 'libfile-which-perl'
-  - 'libhttp-daemon-perl'
-  - 'libxml-treepp-perl'
-  - 'libyaml-perl'
-  - 'libnet-cups-perl'
-  - 'libnet-ip-perl'
-  - 'libdigest-sha-perl'
-  - 'libjson-pp-perl'
-  - 'libsocket-getaddrinfo-perl'
-  - 'libtext-template-perl'
-  - 'lsb-base'
-  - 'xz-utils'
-                                                                       # ]]]
-# .. envvar:: fusioninventory__agent_package_url [[[
-#
-# The URL used to download deb package for fusioninventory-agent.
-#
-# See the official documentation for more informations :
-# http://fusioninventory.org/documentation/agent/installation/linux/deb.html
-#
-fusioninventory__agent_package_url: '{{ "http://debian.fusioninventory.org/downloads/fusioninventory-agent_"+ fusioninventory__agent_version + "_all.deb"
-                                          if (ansible_distribution_release in
-                                              ([ "stretch" ]))
-                                          else "" }}'
-                                                                   # ]]]
+
 # .. envvar:: fusioninventory__agent_deploy_state [[[
 #
 # What is the desired state which this role should achieve ? Possible options :

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
   - name: Debian
     versions:
     - stretch
+  - name: EL
+    versions:
+    - 7
   galaxy_tags:
     - agent
     - fusion

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,10 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+- name: Ensure fusioninventory-agent package from URL
+  apt:
+    deb: '{{ fusioninventory__agent_package_url }}'
+  register: pkg_agent_url_result
+  until: pkg_agent_url_result is success
+  when: ((fusioninventory__agent_package_url) and
+         (fusioninventory__agent_deploy_state == "present"))

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,11 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# http://fusioninventory.org/documentation/agent/installation/linux/rhel.html
+
+- name: Add EPEL Repository
+  yum_repository:
+    name: Epel
+    description: EPEL YUM repo
+    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
+    gpgkey: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,12 @@
 #
 # tasks file for fusioninventory
 
+- name: Include package list per OS
+  include_vars: "{{ item }}"
+  with_first_found:
+  - "{{ ansible_distribution }}.yml"
+  - "{{ ansible_os_family }}.yml"
+
 # Manage dependent packages [[[1
 - name: Ensure dependent packages are installed
   package:
@@ -15,17 +21,16 @@
   when: fusioninventory__agent_deploy_state == "present"
 
 # Manage agent package [[[1
-- name: Ensure fusioninventory-agent package from URL
-  apt:
-    deb: '{{ fusioninventory__agent_package_url }}'
-  register: pkg_agent_url_result
-  until: pkg_agent_url_result is success
-  when: ((fusioninventory__agent_package_url) and
-         (fusioninventory__agent_deploy_state == "present"))
+
+# Specific tasks per OS will be in the include otherwise below
+- include: "{{ item }}"
+  with_first_found:
+  - "{{ ansible_distribution }}.yml"
+  - "{{ ansible_os_family }}.yml"
 
 - name: Ensure fusioninventory-agent package from REPOS
   package:
-    name: 'fusioninventory-agent'
+    name: '{{ fusioninventory__agent_packages }}'
     state: '{{ "present" if (fusioninventory__agent_deploy_state == "present")
            else "absent" }}'
   register: pkg_agent_repo_result

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,41 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. envvar:: fusioninventory__agent_depend_packages [[[
+#
+# List of dependent packages to install.
+fusioninventory__agent_depend_packages:
+  - 'dmidecode'
+  - 'hwdata'
+  - 'hdparm'
+  - 'libuniversal-require-perl'
+  - 'libwww-perl'
+  - 'libparse-edid-perl'
+  - 'libproc-daemon-perl'
+  - 'libfile-which-perl'
+  - 'libhttp-daemon-perl'
+  - 'libxml-treepp-perl'
+  - 'libyaml-perl'
+  - 'libnet-cups-perl'
+  - 'libnet-ip-perl'
+  - 'libdigest-sha-perl'
+  - 'libjson-pp-perl'
+  - 'libsocket-getaddrinfo-perl'
+  - 'libtext-template-perl'
+  - 'lsb-base'
+  - 'xz-utils'
+                                                                       # ]]]
+# .. envvar:: fusioninventory__agent_package_url [[[
+#
+# The URL used to download deb package for fusioninventory-agent.
+#
+# See the official documentation for more informations :
+# http://fusioninventory.org/documentation/agent/installation/linux/deb.html
+#
+fusioninventory__agent_package_url: '{{ "http://debian.fusioninventory.org/downloads/fusioninventory-agent_"+ fusioninventory__agent_version + "_all.deb"
+                                          if (ansible_distribution_release in
+                                              ([ "stretch" ]))
+                                          else "" }}'
+                                                                   # ]]]
+fusioninventory__agent_packages:
+  - 'fusioninventory-agent'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,25 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. envvar:: fusioninventory__agent_depend_packages [[[
+#
+# List of dependent packages to install.
+fusioninventory__agent_depend_packages:
+  - 'dmidecode'
+                                                                       # ]]]
+# .. envvar:: fusioninventory__agent_package_url [[[
+#
+# The URL used to download deb package for fusioninventory-agent.
+#
+# See the official documentation for more informations :
+# http://fusioninventory.org/documentation/agent/installation/linux/deb.html
+#
+fusioninventory__agent_package_url: '{{ "http://debian.fusioninventory.org/downloads/fusioninventory-agent_"+ fusioninventory__agent_version + "_all.deb"
+                                          if (ansible_distribution_release in
+                                              ([ "stretch" ]))
+                                          else "" }}'
+                                                                   # ]]]
+
+fusioninventory__agent_packages:
+  - 'fusioninventory-agent'
+  - 'fusioninventory-agent-task-inventory'


### PR DESCRIPTION
Followed the procedure : http://fusioninventory.org/documentation/agent/installation/linux/rhel.html

- Should possible to add RHEL8 support without huge change
- On RHEL, it's (actually ? ) only possible to install via REPOS ( so not possible via `Ensure fusioninventory-agent package from URL`)