### PR TITLE
Add libyaml-tiny-perl package

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -16,6 +16,7 @@ fusioninventory__agent_depend_packages:
   - 'libhttp-daemon-perl'
   - 'libxml-treepp-perl'
   - 'libyaml-perl'
+  - 'libyaml-tiny-perl'
   - 'libnet-cups-perl'
   - 'libnet-ip-perl'
   - 'libdigest-sha-perl'


### PR DESCRIPTION
Add `libyaml-tiny-perl` package, related with snap module error:

```text
Nov 10 14:29:29 xxxxxxxxxxxxx fusioninventory-agent[84322]: module FusionInventory::Agent::Task::Inventory::Generic::Softwares::Snap disabled: failure to load (Can't locate YAML/Tiny.pm in @INC (you may need to install the YAML::Tiny module) (@INC contains: /usr/share/fusioninventory/lib /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.26.1 /usr/local/share/perl/5.26.1 /usr/lib/x86_64-linux-gnu/perl5/5.26 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.26 /usr/share/perl/5.26 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/fusioninventory/lib/FusionInventory/Agent/Task/Inventory/Generic/Softwares/Snap.pm line 9.
                                                                      BEGIN failed--compilation aborted at /usr/share/fusioninventory/lib/FusionInventory/Agent/Task/Inventory/Generic/Softwares/Snap.pm line 9.
                                                                      Compilation failed in require at /usr/share/fusioninventory/lib/FusionInventory/Agent/Task/Inventory.pm line 224.
                                                                      )
```