### PR TITLE
Fix with_first_found fail when rhel7 vars file is missing

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -17,9 +17,7 @@
   block:
 
   - name: Load additional repository settings for CentOS or RedHat 8
-    include_vars: "{{ item }}"
-    with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
 
   - name: Override repository settings for CentOS <= 8.2
     include_vars: "CentOS-8.2.yml"


### PR DESCRIPTION
Deploying FusionInventory on CentOS 7 I noticed this of error:

```
TASK [ipr-cnrs.fusioninventory : Load additional repository settings for CentOS or RedHat 8] ********************************************************************************************************************fatal: 
[test-centos-7]: FAILED! => {"msg": "No file was found when using first_found. Use errors='ignore' to allow this task to be skipped if no files are found"}
```

Though this task was supposed to be skipped, the error was still triggered. Sorry for not catching this earlier