### PR TITLE
Service status management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancement
 * Upgrade package version from URL from 2.4 to 2.6 (thanks to @roumano - issue #15).
+* Allow service to be managed, (thanks to @yodabzh - issue #17).
 
 ### Fix
 * Switch to Github URL to download deb file (thanks to @roumano - PR #16).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A role to manage FusionInventory agent installation and configuration.
 * **fusioninventory__agent_service_name** : The service name to manage [default : `fusioninventory-agent`].
 * **fusioninventory__agent_service_manage** : If the fusioninventory agent service should be managed [default : `true`].
 * **fusioninventory__agent_conf_src** : Template used to provide agent configuration file [default : `../templates/etc/fusioninventory/agent.cfg.j2`].
+* **fusioninventory__agent_service_status**: Service state, can be started, stopped, restarted, reloaded [default : `started`].
+* **fusioninventory__agent_service_enabled**: Service status, can be enabled (`true`) or disabled (`false`) [default: `true`].
 
 ### Config Specific Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,19 @@ fusioninventory__agent_deploy_state: 'present'
 # The service name to manage.
 #
 fusioninventory__agent_service_name: 'fusioninventory-agent'
+                                                                   # ]]]
+# .. envvar:: fusioninventory__agent_service_status [[[
+#
+# The targeted service status.
+#
+fusioninventory__agent_service_status: 'started'
+                                                                   # ]]]
+
+# .. envvar:: fusioninventory__agent_service_enabled [[[
+#
+# The targeted service status.
+#
+fusioninventory__agent_service_enabled: true
 
                                                                    # ]]]
 # .. envvar:: fusioninventory__agent_service_manage [[[

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,3 +56,10 @@
     mode: '0644'
   when: fusioninventory__agent_deploy_state == "present"
   notify: ['restart fusioninventory-agent service']
+
+- name: Ensure the service is in the correct state
+  service:
+    name: "{{ fusioninventory__agent_service_name }}"
+    state: "{{ fusioninventory__agent_service_status }}"
+    enabled: "{{ fusioninventory__agent_service_enabled }}"
+  when: fusioninventory__agent_deploy_state == "present"


### PR DESCRIPTION
Service can either be enabled or disabled, enabled by default 

Service can either be started, stopped, restarted, reloaded, started by default

this should fix https://github.com/ipr-cnrs/fusioninventory/issues/17