### PR TITLE
Replace include by include_tasks in main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 
 # Specific tasks per OS will be in the include otherwise below
 - name: Include tasks per OS
-  include: "{{ lookup('first_found', params) }}"
+  include_tasks: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:


### PR DESCRIPTION
Fixes error message:
> ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.